### PR TITLE
Add per-server whitelist validation using Pterodactyl API

### DIFF
--- a/src/main/java/fr/pickaria/pterodactylpoweraction/Configuration.java
+++ b/src/main/java/fr/pickaria/pterodactylpoweraction/Configuration.java
@@ -38,6 +38,8 @@ public interface Configuration {
 
     Set<String> getAllServers();
 
+    boolean shouldCheckWhitelist(String serverName);
+
     record PowerCommands(Optional<String> workingDirectory, String start, String stop) {
     }
 }

--- a/src/main/java/fr/pickaria/pterodactylpoweraction/ConnectionListener.java
+++ b/src/main/java/fr/pickaria/pterodactylpoweraction/ConnectionListener.java
@@ -58,6 +58,25 @@ public class ConnectionListener {
         RegisteredServer originalServer = event.getOriginalServer();
         RegisteredServer previousServer = event.getPreviousServer();
 
+        String serverName = originalServer.getServerInfo().getName();
+        if (configurationLoader.getConfiguration().shouldCheckWhitelist(serverName)) {
+            try {
+                boolean whitelisted = configurationLoader.getAPI()
+                        .isPlayerWhitelisted(serverName, event.getPlayer().getUsername())
+                        .join();
+                if (!whitelisted) {
+                    event.setResult(ServerPreConnectEvent.ServerResult.denied());
+                    event.getPlayer().disconnect(Component.text("You are not whitelisted on this server."));
+                    return;
+                }
+            } catch (Exception e) {
+                logger.error("Failed to check whitelist for server {}", serverName, e);
+                event.setResult(ServerPreConnectEvent.ServerResult.denied());
+                event.getPlayer().disconnect(Component.text("Whitelist verification failed."));
+                return;
+            }
+        }
+
         shutdownManager.cancelTask(originalServer);
 
         if (isReachable(originalServer)) {

--- a/src/main/java/fr/pickaria/pterodactylpoweraction/PowerActionAPI.java
+++ b/src/main/java/fr/pickaria/pterodactylpoweraction/PowerActionAPI.java
@@ -6,4 +6,6 @@ public interface PowerActionAPI {
     CompletableFuture<Void> stop(String server);
 
     CompletableFuture<Void> start(String server);
+
+    CompletableFuture<Boolean> isPlayerWhitelisted(String server, String playerName);
 }

--- a/src/main/java/fr/pickaria/pterodactylpoweraction/api/PterodactylAPI.java
+++ b/src/main/java/fr/pickaria/pterodactylpoweraction/api/PterodactylAPI.java
@@ -7,11 +7,14 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.regex.Pattern;
 
 public class PterodactylAPI implements PowerActionAPI {
     private final HttpClient httpClient = HttpClient.newHttpClient();
@@ -45,6 +48,43 @@ public class PterodactylAPI implements PowerActionAPI {
         String identifier = serverIdentifier.get();
         logger.info("Starting server {}", server);
         return makeRequest(identifier, "start");
+    }
+
+    @Override
+    public CompletableFuture<Boolean> isPlayerWhitelisted(String server, String playerName) {
+        Optional<String> serverIdentifier = configuration.getPterodactylServerIdentifier(server);
+        if (serverIdentifier.isEmpty()) {
+            return CompletableFuture.completedFuture(false);
+        }
+
+        String identifier = serverIdentifier.get();
+        String baseUrl = configuration.getPterodactylClientApiBaseURL().orElse("");
+        if (baseUrl.isEmpty() || configuration.getPterodactylApiKey().isEmpty()) {
+            return CompletableFuture.completedFuture(false);
+        }
+
+        HttpRequest request;
+        try {
+            String fileParam = URLEncoder.encode("/whitelist.json", StandardCharsets.UTF_8);
+            URI uri = new URI(baseUrl + "/servers/" + identifier + "/files/contents?file=" + fileParam);
+            request = HttpRequest.newBuilder()
+                    .uri(uri)
+                    .header("Authorization", "Bearer " + configuration.getPterodactylApiKey().get())
+                    .GET()
+                    .build();
+        } catch (URISyntaxException e) {
+            return CompletableFuture.failedFuture(e);
+        }
+
+        return sendRequest(request, HttpResponse.BodyHandlers.ofString())
+                .thenApply(response -> {
+                    if (response.statusCode() != 200) {
+                        return false;
+                    }
+                    String body = response.body();
+                    Pattern pattern = Pattern.compile("\\\"name\\\"\\s*:\\s*\\\"" + Pattern.quote(playerName) + "\\\"");
+                    return pattern.matcher(body).find();
+                });
     }
 
     public CompletableFuture<Boolean> exists(String server) {

--- a/src/main/java/fr/pickaria/pterodactylpoweraction/api/ShellCommandAPI.java
+++ b/src/main/java/fr/pickaria/pterodactylpoweraction/api/ShellCommandAPI.java
@@ -43,6 +43,11 @@ public class ShellCommandAPI implements PowerActionAPI {
         return runCommands(powerCommand.workingDirectory(), powerCommand.start());
     }
 
+    @Override
+    public CompletableFuture<Boolean> isPlayerWhitelisted(String server, String playerName) {
+        return CompletableFuture.completedFuture(true);
+    }
+
     private CompletableFuture<Void> runCommands(Optional<String> workingDirectory, String command) {
         return CompletableFuture.runAsync(() -> {
             ProcessBuilder pb = new ProcessBuilder(command.split(" "));

--- a/src/main/java/fr/pickaria/pterodactylpoweraction/configuration/ConfigurationDoctor.java
+++ b/src/main/java/fr/pickaria/pterodactylpoweraction/configuration/ConfigurationDoctor.java
@@ -107,7 +107,22 @@ public class ConfigurationDoctor {
                     }
 
                     if (apiType == APIType.PTERODACTYL) {
-                        if (value instanceof String uuid) {
+                        String uuid = null;
+                        if (value instanceof String) {
+                            uuid = (String) value;
+                        } else if (value instanceof Map serverConfig) {
+                            Object identifier = serverConfig.get("identifier");
+                            if (identifier instanceof String) {
+                                uuid = (String) identifier;
+                            } else {
+                                logger.warn("'servers.{}.identifier' is missing or not a string.", key);
+                                isValid = false;
+                            }
+                        } else {
+                            logger.warn("The server '{}' entry must be a string or map when type is 'pterodactyl'.", key);
+                            isValid = false;
+                        }
+                        if (uuid != null) {
                             if (!this.isUUID(uuid)) {
                                 logger.warn("The identifier '{}' for server '{}' must be a valid UUID. You can find the 'Server ID' under the 'Settings' tab of your server on your Pterodactyl panel.", uuid, key);
                                 isValid = false;
@@ -123,9 +138,6 @@ public class ConfigurationDoctor {
                                     isValid = false;
                                 }
                             }
-                        } else {
-                            logger.warn("The server '{}' entry must be a string when type is 'pterodactyl'.", key);
-                            isValid = false;
                         }
                     } else if (apiType == APIType.SHELL) {
                         if (value instanceof Map) {

--- a/src/main/java/fr/pickaria/pterodactylpoweraction/configuration/YamlConfiguration.java
+++ b/src/main/java/fr/pickaria/pterodactylpoweraction/configuration/YamlConfiguration.java
@@ -70,6 +70,11 @@ public class YamlConfiguration implements Configuration {
             Object configuration = getServerConfiguration(serverName);
             if (configuration instanceof String) {
                 return Optional.of((String) configuration);
+            } else if (configuration instanceof Map serverConfiguration) {
+                Object identifier = serverConfiguration.get("identifier");
+                if (identifier instanceof String) {
+                    return Optional.of((String) identifier);
+                }
             }
         } catch (NoSuchElementException e) {
             // Fall through to return empty
@@ -119,6 +124,21 @@ public class YamlConfiguration implements Configuration {
     @Override
     public Set<String> getAllServers() {
         return getServerMap().keySet();
+    }
+
+    @Override
+    public boolean shouldCheckWhitelist(String serverName) {
+        try {
+            Object configuration = getServerConfiguration(serverName);
+            if (configuration instanceof Map serverConfiguration) {
+                Object whitelist = serverConfiguration.get("whitelist");
+                if (whitelist instanceof Boolean) {
+                    return (Boolean) whitelist;
+                }
+            }
+        } catch (NoSuchElementException ignored) {
+        }
+        return false;
     }
 
     @Override

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -19,9 +19,11 @@ pterodactyl_client_api_base_url: "https://example.com/api/client"
 # - For Pterodactyl: Use the server's identifier from the panel (found under "Settings" > "Debug Information")
 # - For Shell: Define start/stop commands and optional working directory
 servers:
-  # Example for Pterodactyl:
-  survival: "abc123"
-  
+  # Example for Pterodactyl with whitelist check enabled:
+  survival:
+    identifier: "abc123"
+    whitelist: true
+
   # Example for Shell (uncomment if using shell type):
   # survival:
   #   working_directory: "/path/to/server"  # Optional, defaults to current directory


### PR DESCRIPTION
## Summary
- verify join requests against server whitelist using Pterodactyl API
- allow enabling whitelist checks per server via config
- document whitelist-enabled server configuration example

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6895ba0322f8832c99cf4779b7354314