### PR TITLE
Handle whitelist and document server configuration

### DIFF
--- a/docs/Configuration-guide.md
+++ b/docs/Configuration-guide.md
@@ -45,7 +45,10 @@ When `type` or `ping_method` is set to `"pterodactyl"`, the following settings a
 pterodactyl_api_key: "ptlc_xxx"
 pterodactyl_client_api_base_url: "https://example.com/api/client"
 servers:
-  server_name: "server_id"
+  limbo: "21b8d887-7d47-4a0b-bbfe-4c4a6318dcf0" # Short form
+  survival:
+    identifier: "e25eccf6-2bc6-4264-b34a-c8ab02a5c986"
+    whitelist: true
 ```
 
 | Option                            | Description                                                |
@@ -53,6 +56,8 @@ servers:
 | `pterodactyl_api_key`             | Client API key from Pterodactyl panel                      |
 | `pterodactyl_client_api_base_url` | Base URL for the Pterodactyl client API                    |
 | `servers`                         | Mapping of Velocity server names to Pterodactyl server IDs |
+
+Each server entry may either be a simple string containing the server's identifier or a map with an `identifier` field. When using the map form, an optional `whitelist` boolean can enable whitelist verification for that server.
 
 ### Shell-Specific Settings
 
@@ -64,13 +69,15 @@ servers:
     working_directory: "/path/to/directory"  # Optional
     start: "command to start server"
     stop: "command to stop server"
+    whitelist: true  # Optional
 ```
 
-| Option              | Description                               |
-|---------------------|-------------------------------------------|
-| `working_directory` | Directory to run commands from (optional) |
-| `start`             | Command to start the server               |
-| `stop`              | Command to stop the server                |
+| Option              | Description                                               |
+|---------------------|-----------------------------------------------------------|
+| `working_directory` | Directory to run commands from (optional)                 |
+| `start`             | Command to start the server                               |
+| `stop`              | Command to stop the server                                |
+| `whitelist`         | Enable whitelist verification using `whitelist.json` file |
 
 ## Shutdown Behavior Options
 
@@ -130,8 +137,11 @@ pterodactyl_api_key: "ptlc_xxx"
 pterodactyl_client_api_base_url: "https://panel.example.com/api/client"
 servers:
   limbo: "21b8d887-7d47-4a0b-bbfe-4c4a6318dcf0"
-  survival: "e25eccf6-2bc6-4264-b34a-c8ab02a5c986"
-  creative: "f33b8741-e46c-4386-9281-05eaa2e88333"
+  survival:
+    identifier: "e25eccf6-2bc6-4264-b34a-c8ab02a5c986"
+    whitelist: true
+  creative:
+    identifier: "f33b8741-e46c-4386-9281-05eaa2e88333"
 waiting_server_name: "limbo"
 ping_method: "pterodactyl"
 maximum_ping_duration: 60
@@ -149,6 +159,7 @@ servers:
     working_directory: "/home/minecraft/servers"
     start: "docker compose start survival"
     stop: "docker compose stop survival"
+    whitelist: true
   creative:
     working_directory: "/home/minecraft/servers"
     start: "docker compose start creative"

--- a/src/main/java/fr/pickaria/pterodactylpoweraction/ConnectionListener.java
+++ b/src/main/java/fr/pickaria/pterodactylpoweraction/ConnectionListener.java
@@ -66,13 +66,13 @@ public class ConnectionListener {
                         .join();
                 if (!whitelisted) {
                     event.setResult(ServerPreConnectEvent.ServerResult.denied());
-                    event.getPlayer().disconnect(Component.text("You are not whitelisted on this server."));
+                    event.getPlayer().disconnect(Component.translatable("whitelist.not.whitelisted"));
                     return;
                 }
             } catch (Exception e) {
                 logger.error("Failed to check whitelist for server {}", serverName, e);
                 event.setResult(ServerPreConnectEvent.ServerResult.denied());
-                event.getPlayer().disconnect(Component.text("Whitelist verification failed."));
+                event.getPlayer().disconnect(Component.translatable("whitelist.verification.failed"));
                 return;
             }
         }

--- a/src/main/java/fr/pickaria/pterodactylpoweraction/api/PterodactylAPI.java
+++ b/src/main/java/fr/pickaria/pterodactylpoweraction/api/PterodactylAPI.java
@@ -1,5 +1,6 @@
 package fr.pickaria.pterodactylpoweraction.api;
 
+import com.google.gson.Gson;
 import fr.pickaria.pterodactylpoweraction.Configuration;
 import fr.pickaria.pterodactylpoweraction.PowerActionAPI;
 import org.slf4j.Logger;
@@ -14,9 +15,9 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.regex.Pattern;
 
 public class PterodactylAPI implements PowerActionAPI {
+    private static final Gson GSON = new Gson();
     private final HttpClient httpClient = HttpClient.newHttpClient();
     private final Logger logger;
     private final Configuration configuration;
@@ -81,9 +82,19 @@ public class PterodactylAPI implements PowerActionAPI {
                     if (response.statusCode() != 200) {
                         return false;
                     }
-                    String body = response.body();
-                    Pattern pattern = Pattern.compile("\\\"name\\\"\\s*:\\s*\\\"" + Pattern.quote(playerName) + "\\\"");
-                    return pattern.matcher(body).find();
+                    try {
+                        WhitelistEntry[] entries = GSON.fromJson(response.body(), WhitelistEntry[].class);
+                        if (entries != null) {
+                            for (WhitelistEntry entry : entries) {
+                                if (playerName.equalsIgnoreCase(entry.name())) {
+                                    return true;
+                                }
+                            }
+                        }
+                    } catch (Exception e) {
+                        logger.error("Failed to parse whitelist for server {}", server, e);
+                    }
+                    return false;
                 });
     }
 

--- a/src/main/java/fr/pickaria/pterodactylpoweraction/api/ShellCommandAPI.java
+++ b/src/main/java/fr/pickaria/pterodactylpoweraction/api/ShellCommandAPI.java
@@ -1,16 +1,20 @@
 package fr.pickaria.pterodactylpoweraction.api;
 
+import com.google.gson.Gson;
 import fr.pickaria.pterodactylpoweraction.Configuration;
 import fr.pickaria.pterodactylpoweraction.PowerActionAPI;
 import org.slf4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 public class ShellCommandAPI implements PowerActionAPI {
+    private static final Gson GSON = new Gson();
     private final Logger logger;
     private final Configuration configuration;
 
@@ -45,7 +49,33 @@ public class ShellCommandAPI implements PowerActionAPI {
 
     @Override
     public CompletableFuture<Boolean> isPlayerWhitelisted(String server, String playerName) {
-        return CompletableFuture.completedFuture(true);
+        Optional<Configuration.PowerCommands> powerCommands = configuration.getPowerCommands(server);
+        if (powerCommands.isEmpty()) {
+            return CompletableFuture.completedFuture(false);
+        }
+
+        Optional<String> workingDirectory = powerCommands.get().workingDirectory();
+        Path whitelistPath = workingDirectory.map(Path::of).orElse(Path.of(".")).resolve("whitelist.json");
+
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                if (!Files.exists(whitelistPath)) {
+                    return false;
+                }
+                String content = Files.readString(whitelistPath);
+                WhitelistEntry[] entries = GSON.fromJson(content, WhitelistEntry[].class);
+                if (entries != null) {
+                    for (WhitelistEntry entry : entries) {
+                        if (playerName.equalsIgnoreCase(entry.name())) {
+                            return true;
+                        }
+                    }
+                }
+            } catch (IOException e) {
+                logger.error("Failed to read whitelist file {}", whitelistPath, e);
+            }
+            return false;
+        });
     }
 
     private CompletableFuture<Void> runCommands(Optional<String> workingDirectory, String command) {

--- a/src/main/java/fr/pickaria/pterodactylpoweraction/api/WhitelistEntry.java
+++ b/src/main/java/fr/pickaria/pterodactylpoweraction/api/WhitelistEntry.java
@@ -1,0 +1,3 @@
+package fr.pickaria.pterodactylpoweraction.api;
+
+public record WhitelistEntry(String uuid, String name) {}

--- a/src/main/java/fr/pickaria/pterodactylpoweraction/configuration/ConfigurationDoctor.java
+++ b/src/main/java/fr/pickaria/pterodactylpoweraction/configuration/ConfigurationDoctor.java
@@ -106,6 +106,14 @@ public class ConfigurationDoctor {
                         isValid = false;
                     }
 
+                    if (value instanceof Map serverConfig) {
+                        Object whitelist = serverConfig.get("whitelist");
+                        if (whitelist != null && !(whitelist instanceof Boolean)) {
+                            logger.warn("'servers.{}.whitelist' must be a boolean if specified.", key);
+                            isValid = false;
+                        }
+                    }
+
                     if (apiType == APIType.PTERODACTYL) {
                         String uuid = null;
                         if (value instanceof String) {

--- a/src/main/resources/PterodactylPowerAction/Bundle_de.properties
+++ b/src/main/resources/PterodactylPowerAction/Bundle_de.properties
@@ -13,3 +13,5 @@ command.reload.success=Die Konfiguration wurde erfolgreich neu geladen!
 command.reload.error=Die Konfiguration enthält Fehler und konnte nicht neu geladen werden. Sieh dir die Serverkonsole für Details an.
 command.doctor.start=Führe Diagnoseprüfungen durch... Sieh dir die Serverkonsole für Details an.
 command.clear.start=Leere Server werden gestoppt
+whitelist.not.whitelisted=Du bist nicht auf der Whitelist dieses Servers.
+whitelist.verification.failed=Whitelist-Überprüfung fehlgeschlagen.

--- a/src/main/resources/PterodactylPowerAction/Bundle_en.properties
+++ b/src/main/resources/PterodactylPowerAction/Bundle_en.properties
@@ -13,3 +13,5 @@ command.reload.success=Configuration successfully reloaded!
 command.reload.error=Configuration contains error and could not be reloaded. Check the server's console for details.
 command.doctor.start=Performing diagnostic checks... Check the server's console for details.
 command.clear.start=Stopping empty servers...
+whitelist.not.whitelisted=You are not whitelisted on this server.
+whitelist.verification.failed=Whitelist verification failed.

--- a/src/main/resources/PterodactylPowerAction/Bundle_fr.properties
+++ b/src/main/resources/PterodactylPowerAction/Bundle_fr.properties
@@ -13,3 +13,5 @@ command.reload.success=Configuration rechargée avec succès !
 command.reload.error=La configuration contient une erreur et n'a pas pu être rechargée. Vérifiez la console du serveur pour plus de détails.
 command.doctor.start=Exécution des vérifications diagnostiques… Vérifiez la console du serveur pour plus de détails.
 command.clear.start=Arrêt des serveurs…
+whitelist.not.whitelisted=Vous n'êtes pas sur la liste blanche de ce serveur.
+whitelist.verification.failed=La vérification de la liste blanche a échoué.


### PR DESCRIPTION
## Summary
- Translate whitelist messages and add bundle entries
- Use Gson for whitelist checks and support shell mode
- Document whitelist option and server declaration styles

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6895d8ab5e48832c999fab03a5882497