### PR TITLE
Improve bossbar reload handling and simplify config

### DIFF
--- a/docs/Configuration-guide.md
+++ b/docs/Configuration-guide.md
@@ -35,8 +35,7 @@ shutdown_behaviour: "shutdown_all"
 | `maximum_ping_duration`              | Maximum time (in seconds) to wait for a server to respond                               | `60`             | Any positive integer                              |
 | `shutdown_after_duration`            | Time (in seconds) after which an empty server will be shut down                         | `3600`           | Any positive integer                              |
 | `redirect_to_waiting_server_on_kick` | Whether to redirect players to the waiting server when kicked from a backend server     | `false`          | `true`, `false`                                   |
-| `bossbar.enabled`                    | Show an progress boss bar while a server starts (Pterodactyl API only)                  | `true`           | `true`, `false`                                   |
-| `bossbar.show_progress`              | Whether the boss bar should display progress                                            | `true`           | `true`, `false`                                   |
+| `bossbar.enabled`                    | Show a progress boss bar while a server starts (Pterodactyl API only)                  | `true`           | `true`, `false`                                   |
 | `shutdown_behaviour`                 | What to do with servers when the proxy shuts down                                       | `"shutdown_all"` | `"shutdown_all"`, `"shutdown_empty"`, `"nothing"` |
 
 ### Pterodactyl-Specific Settings
@@ -50,7 +49,6 @@ servers:
   server_name: "server_id"
 bossbar:
   enabled: true
-  show_progress: true
 ```
 
 | Option                            | Description                                                |
@@ -145,7 +143,6 @@ shutdown_after_duration: 3600
 redirect_to_waiting_server_on_kick: false
 bossbar:
   enabled: true
-  show_progress: true
 shutdown_behaviour: "shutdown_empty"
 ```
 

--- a/src/main/java/fr/pickaria/pterodactylpoweraction/Configuration.java
+++ b/src/main/java/fr/pickaria/pterodactylpoweraction/Configuration.java
@@ -40,8 +40,6 @@ public interface Configuration {
 
     boolean isBossBarEnabled();
 
-    boolean showBossBarProgress();
-
     record PowerCommands(Optional<String> workingDirectory, String start, String stop) {
     }
 }

--- a/src/main/java/fr/pickaria/pterodactylpoweraction/ServerStartBossBar.java
+++ b/src/main/java/fr/pickaria/pterodactylpoweraction/ServerStartBossBar.java
@@ -24,7 +24,6 @@ class ServerStartBossBar {
     private final Configuration configuration;
     private final String serverName;
     private final Logger logger;
-    private final boolean showProgress;
     private final BossBar bossBar;
     private ScheduledExecutorService scheduler;
     private WebSocket webSocket;
@@ -48,11 +47,9 @@ class ServerStartBossBar {
         this.configuration = configuration;
         this.serverName = serverName;
         this.logger = logger;
-        this.showProgress = configuration.showBossBarProgress();
-        float progress = this.showProgress ? 0f : 1f;
         this.bossBar = BossBar.bossBar(
                 Component.translatable(messageKey, Component.text(serverName)),
-                progress,
+                0f,
                 BossBar.Color.YELLOW,
                 BossBar.Overlay.PROGRESS
         );
@@ -61,11 +58,7 @@ class ServerStartBossBar {
     void start() {
         messageKey = "bossbar.starting";
         dots = 0;
-        if (showProgress) {
-            bossBar.progress(0f);
-        } else {
-            bossBar.progress(1f);
-        }
+        bossBar.progress(0f);
         bossBar.name(Component.translatable(messageKey, Component.text(serverName)));
         audience.showBossBar(bossBar);
         scheduler = Executors.newSingleThreadScheduledExecutor();
@@ -93,11 +86,7 @@ class ServerStartBossBar {
         audience.hideBossBar(bossBar);
         messageKey = "bossbar.starting";
         dots = 0;
-        if (showProgress) {
-            bossBar.progress(0f);
-        } else {
-            bossBar.progress(1f);
-        }
+        bossBar.progress(0f);
         bossBar.name(Component.translatable(messageKey, Component.text(serverName)));
     }
 
@@ -121,9 +110,7 @@ class ServerStartBossBar {
         for (Phase phase : PHASES) {
             if (phase.pattern.matcher(line).find()) {
                 messageKey = phase.key;
-                if (showProgress) {
-                    bossBar.progress(Math.max(bossBar.progress(), phase.progress));
-                }
+                bossBar.progress(Math.max(bossBar.progress(), phase.progress));
                 break;
             }
         }

--- a/src/main/java/fr/pickaria/pterodactylpoweraction/StartingServer.java
+++ b/src/main/java/fr/pickaria/pterodactylpoweraction/StartingServer.java
@@ -29,7 +29,8 @@ public class StartingServer implements ForwardingAudience {
     private final Logger logger;
     private final Messager messager;
     private final AtomicBoolean isStarting = new AtomicBoolean(false);
-    private final ServerStartBossBar bossBar;
+    private ServerStartBossBar bossBar;
+    private static final Set<StartingServer> INSTANCES = ConcurrentHashMap.newKeySet();
 
     public StartingServer(RegisteredServer server, ConfigurationLoader configurationLoader, ShutdownManager shutdownManager, Logger logger, Messager messager) {
         this.server = server;
@@ -37,9 +38,8 @@ public class StartingServer implements ForwardingAudience {
         this.shutdownManager = shutdownManager;
         this.logger = logger;
         this.messager = messager;
-        this.bossBar = configurationLoader.getConfiguration().isBossBarEnabled() ?
-                new ServerStartBossBar(this, configurationLoader.getConfiguration(), server.getServerInfo().getName(), logger) :
-                null;
+        INSTANCES.add(this);
+        reloadBossBar();
     }
 
     /**
@@ -148,5 +148,23 @@ public class StartingServer implements ForwardingAudience {
     @Override
     public @NotNull Iterable<? extends Audience> audiences() {
         return waitingPlayers;
+    }
+
+    private void reloadBossBar() {
+        if (bossBar != null) {
+            bossBar.stop();
+        }
+        bossBar = configurationLoader.getConfiguration().isBossBarEnabled()
+                ? new ServerStartBossBar(this, configurationLoader.getConfiguration(), server.getServerInfo().getName(), logger)
+                : null;
+        if (bossBar != null && isStarting.get()) {
+            bossBar.start();
+        }
+    }
+
+    public static void reloadAll() {
+        for (StartingServer server : INSTANCES) {
+            server.reloadBossBar();
+        }
     }
 }

--- a/src/main/java/fr/pickaria/pterodactylpoweraction/commands/PterodactylPowerActionCommand.java
+++ b/src/main/java/fr/pickaria/pterodactylpoweraction/commands/PterodactylPowerActionCommand.java
@@ -13,6 +13,7 @@ import fr.pickaria.messager.Messager;
 import fr.pickaria.messager.components.Text;
 import fr.pickaria.pterodactylpoweraction.PterodactylPowerAction;
 import fr.pickaria.pterodactylpoweraction.ShutdownManager;
+import fr.pickaria.pterodactylpoweraction.StartingServer;
 import fr.pickaria.pterodactylpoweraction.configuration.ConfigurationDoctor;
 import fr.pickaria.pterodactylpoweraction.configuration.ConfigurationLoader;
 import fr.pickaria.pterodactylpoweraction.configuration.ShutdownBehaviour;
@@ -73,6 +74,7 @@ public class PterodactylPowerActionCommand {
         CommandSource source = context.getSource();
 
         if (configurationLoader.reload()) {
+            StartingServer.reloadAll();
             messager.info(source, "command.reload.success");
         } else {
             messager.error(source, "command.reload.error");

--- a/src/main/java/fr/pickaria/pterodactylpoweraction/configuration/YamlConfiguration.java
+++ b/src/main/java/fr/pickaria/pterodactylpoweraction/configuration/YamlConfiguration.java
@@ -25,7 +25,6 @@ public class YamlConfiguration implements Configuration {
     private static final boolean DEFAULT_START_WAITING_SERVER = true;
     private static final PingMethod DEFAULT_PING_METHOD = PingMethod.PING;
     private static final boolean DEFAULT_BOSSBAR_ENABLED = true;
-    private static final boolean DEFAULT_BOSSBAR_SHOW_PROGRESS = true;
 
     public YamlConfiguration(File file, Logger logger) throws IOException {
         this.logger = logger;
@@ -132,22 +131,6 @@ public class YamlConfiguration implements Configuration {
                     return DEFAULT_BOSSBAR_ENABLED;
                 })
                 .orElse(DEFAULT_BOSSBAR_ENABLED);
-    }
-
-    @Override
-    public boolean showBossBarProgress() {
-        if (!isBossBarEnabled()) {
-            return false;
-        }
-        return get("bossbar", Map.class)
-                .map(map -> {
-                    Object show = map.get("show_progress");
-                    if (show instanceof Boolean b) {
-                        return b;
-                    }
-                    return DEFAULT_BOSSBAR_SHOW_PROGRESS;
-                })
-                .orElse(DEFAULT_BOSSBAR_SHOW_PROGRESS);
     }
 
     @Override

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -69,7 +69,6 @@ redirect_to_waiting_server_on_kick: false
 # Only works when using the Pterodactyl API.
 bossbar:
   enabled: true
-  show_progress: true
 
 # PROXY SHUTDOWN BEHAVIOR
 # ----------------------


### PR DESCRIPTION
## Summary
- Make startup boss bar refresh on plugin reload
- Remove `bossbar.show_progress` option from code and docs

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689b955c6884832caacea27e70db6062