### PR TITLE
Simplify bossbar configuration

### DIFF
--- a/docs/Configuration-guide.md
+++ b/docs/Configuration-guide.md
@@ -35,7 +35,7 @@ shutdown_behaviour: "shutdown_all"
 | `maximum_ping_duration`              | Maximum time (in seconds) to wait for a server to respond                               | `60`             | Any positive integer                              |
 | `shutdown_after_duration`            | Time (in seconds) after which an empty server will be shut down                         | `3600`           | Any positive integer                              |
 | `redirect_to_waiting_server_on_kick` | Whether to redirect players to the waiting server when kicked from a backend server     | `false`          | `true`, `false`                                   |
-| `bossbar`                    | Show a progress boss bar while a server starts (Pterodactyl API only)                  | `true`           | `true`, `false`                                   |
+| `bossbar`                            | Show a progress boss bar while a server starts (Pterodactyl API only)                   | `true`           | `true`, `false`                                   |
 | `shutdown_behaviour`                 | What to do with servers when the proxy shuts down                                       | `"shutdown_all"` | `"shutdown_all"`, `"shutdown_empty"`, `"nothing"` |
 
 ### Pterodactyl-Specific Settings

--- a/docs/Configuration-guide.md
+++ b/docs/Configuration-guide.md
@@ -35,7 +35,7 @@ shutdown_behaviour: "shutdown_all"
 | `maximum_ping_duration`              | Maximum time (in seconds) to wait for a server to respond                               | `60`             | Any positive integer                              |
 | `shutdown_after_duration`            | Time (in seconds) after which an empty server will be shut down                         | `3600`           | Any positive integer                              |
 | `redirect_to_waiting_server_on_kick` | Whether to redirect players to the waiting server when kicked from a backend server     | `false`          | `true`, `false`                                   |
-| `bossbar.enabled`                    | Show a progress boss bar while a server starts (Pterodactyl API only)                  | `true`           | `true`, `false`                                   |
+| `bossbar`                    | Show a progress boss bar while a server starts (Pterodactyl API only)                  | `true`           | `true`, `false`                                   |
 | `shutdown_behaviour`                 | What to do with servers when the proxy shuts down                                       | `"shutdown_all"` | `"shutdown_all"`, `"shutdown_empty"`, `"nothing"` |
 
 ### Pterodactyl-Specific Settings
@@ -50,8 +50,7 @@ servers:
   survival:
     identifier: "e25eccf6-2bc6-4264-b34a-c8ab02a5c986"
     whitelist: true
-bossbar:
-  enabled: true
+bossbar: true
 ```
 
 | Option                            | Description                                                |
@@ -152,8 +151,7 @@ ping_method: "pterodactyl"
 maximum_ping_duration: 60
 shutdown_after_duration: 3600
 redirect_to_waiting_server_on_kick: false
-bossbar:
-  enabled: true
+bossbar: true
 shutdown_behaviour: "shutdown_empty"
 ```
 

--- a/src/main/java/fr/pickaria/pterodactylpoweraction/configuration/YamlConfiguration.java
+++ b/src/main/java/fr/pickaria/pterodactylpoweraction/configuration/YamlConfiguration.java
@@ -127,15 +127,7 @@ public class YamlConfiguration implements Configuration {
         if (getAPIType() == APIType.SHELL) {
             return false;
         }
-        return get("bossbar", Map.class)
-                .map(map -> {
-                    Object enabled = map.get("enabled");
-                    if (enabled instanceof Boolean b) {
-                        return b;
-                    }
-                    return DEFAULT_BOSSBAR_ENABLED;
-                })
-                .orElse(DEFAULT_BOSSBAR_ENABLED);
+        return getBoolean("bossbar", DEFAULT_BOSSBAR_ENABLED);
     }
 
     @Override

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -69,8 +69,7 @@ redirect_to_waiting_server_on_kick: false
 # ---------------
 # Displays an animated boss bar while a managed server is starting.
 # Only works when using the Pterodactyl API.
-bossbar:
-  enabled: true
+bossbar: true
 
 # PROXY SHUTDOWN BEHAVIOR
 # ----------------------


### PR DESCRIPTION
## Summary
- replace bossbar configuration block with single boolean flag
- update configuration loading to read new flag
- document simplified bossbar setting in configuration guide

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_689cd026cd40832ca5eec61acf0f5fcd