### PR TITLE
Fix MOTD caching and fallback

### DIFF
--- a/docs/Server-list-options.md
+++ b/docs/Server-list-options.md
@@ -5,5 +5,5 @@ The following configuration options control how server status is displayed in th
 | Option | Description | Default | Values |
 |--------|-------------|---------|--------|
 | `state_ping` | Replace the players/ping text with server state when offline or starting | `false` | `true`, `false` |
-| `cache_motd` | Cache the backend MOTD and show it while the server is offline | `false` | `true`, `false` |
+| `cache_motd` | Cache the backend MOTD one minute after a server starts and show it while the server is offline; falls back to state messages if no cache exists | `false` | `true`, `false` |
 | `state_motd` | Show server state in the MOTD when offline or starting (disables `cache_motd`) | `false` | `true`, `false` |

--- a/src/main/java/fr/pickaria/pterodactylpoweraction/PingListener.java
+++ b/src/main/java/fr/pickaria/pterodactylpoweraction/PingListener.java
@@ -82,7 +82,14 @@ public class PingListener {
                 builder.description(translatedComponent("state.motd.offline", NamedTextColor.RED));
             }
         } else if (config.getCacheMotd()) {
-            motdCache.get(serverName).ifPresent(builder::description);
+            Optional<Component> cached = motdCache.get(serverName);
+            if (cached.isPresent()) {
+                builder.description(cached.get());
+            } else if (state == ServerState.STARTING) {
+                builder.description(translatedComponent("state.motd.starting", NamedTextColor.GOLD));
+            } else if (state != ServerState.RUNNING) {
+                builder.description(translatedComponent("state.motd.offline", NamedTextColor.RED));
+            }
         }
 
         event.setPing(builder.build());

--- a/src/main/java/fr/pickaria/pterodactylpoweraction/PterodactylPowerAction.java
+++ b/src/main/java/fr/pickaria/pterodactylpoweraction/PterodactylPowerAction.java
@@ -103,6 +103,7 @@ public class PterodactylPowerAction {
                     if (!onlineChecker.isRunningNow()) {
                         PowerActionAPI api = configurationLoader.getAPI();
                         api.start(server.getServerInfo().getName());
+                        shutdownManager.scheduleMotdCache(server, Duration.ofMinutes(1));
                     }
                 });
     }

--- a/src/main/java/fr/pickaria/pterodactylpoweraction/ShutdownManager.java
+++ b/src/main/java/fr/pickaria/pterodactylpoweraction/ShutdownManager.java
@@ -47,6 +47,16 @@ public class ShutdownManager {
         scheduleShutdownTask(server, afterDuration);
     }
 
+    public void scheduleMotdCache(RegisteredServer server, Duration delay) {
+        if (!configurationLoader.getConfiguration().getCacheMotd()) {
+            return;
+        }
+        proxy.getScheduler()
+                .buildTask(plugin, () -> motdCache.update(server))
+                .delay(delay)
+                .schedule();
+    }
+
     public void shutdownAll(ShutdownBehaviour shutdownBehaviour, Duration afterDuration) {
         switch (shutdownBehaviour) {
             case SHUTDOWN_EMPTY: {

--- a/src/main/java/fr/pickaria/pterodactylpoweraction/StartingServer.java
+++ b/src/main/java/fr/pickaria/pterodactylpoweraction/StartingServer.java
@@ -12,6 +12,7 @@ import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
+import java.time.Duration;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
@@ -68,6 +69,10 @@ public class StartingServer implements ForwardingAudience {
         try {
             waitForServer();
             fr.pickaria.pterodactylpoweraction.state.ServerStateManager.setState(server.getServerInfo().getName(), fr.pickaria.pterodactylpoweraction.state.ServerState.RUNNING);
+
+            if (configurationLoader.getConfiguration().getCacheMotd()) {
+                shutdownManager.scheduleMotdCache(server, Duration.ofMinutes(1));
+            }
 
             for (Player player : waitingPlayers) {
                 if (player.isActive()) {

--- a/src/main/java/fr/pickaria/pterodactylpoweraction/state/MotdCache.java
+++ b/src/main/java/fr/pickaria/pterodactylpoweraction/state/MotdCache.java
@@ -5,6 +5,7 @@ import com.velocitypowered.api.proxy.server.ServerPing;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import org.slf4j.Logger;
+import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.IOException;
@@ -21,21 +22,32 @@ public class MotdCache {
     private final Path file;
     private final Logger logger;
     private final Map<String, String> cache = new HashMap<>();
-    private final Yaml yaml = new Yaml();
+    private final Yaml yaml;
     private final GsonComponentSerializer serializer = GsonComponentSerializer.gson();
 
     public MotdCache(Path dataDirectory, Logger logger) {
         this.file = dataDirectory.resolve("motd-cache.yml");
         this.logger = logger;
+
+        DumperOptions options = new DumperOptions();
+        options.setDefaultScalarStyle(DumperOptions.ScalarStyle.DOUBLE_QUOTED);
+        this.yaml = new Yaml(options);
+
         load();
     }
 
     private void load() {
         if (Files.exists(file)) {
             try (InputStream in = Files.newInputStream(file)) {
-                Map<String, String> loaded = yaml.load(in);
+                Map<String, Object> loaded = yaml.load(in);
                 if (loaded != null) {
-                    cache.putAll(loaded);
+                    loaded.forEach((key, value) -> {
+                        if (value instanceof String) {
+                            cache.put(key, (String) value);
+                        } else {
+                            logger.warn("Invalid MOTD cache entry for {}", key);
+                        }
+                    });
                 }
             } catch (IOException e) {
                 logger.warn("Failed to load MOTD cache", e);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -79,6 +79,7 @@ shutdown_behaviour: "shutdown_all"
 # Replace the players/ping text when the server is offline or starting
 state_ping: false
 # Cache the MOTD of backend servers so it is shown even when they are offline
+# Cache occurs one minute after a server starts (falls back to state messages if no cache exists)
 cache_motd: false
 # Show server state in the MOTD when servers are offline or starting. Disables cache_motd when true
 state_motd: false


### PR DESCRIPTION
## Summary
- Ensure cached MOTDs are stored as strings and validated when loading
- Show offline/starting messages when no cached MOTD exists
- Cache MOTD one minute after server starts
- Document cache fallback behavior

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689e5787c09c832c8bf8e21fea190cda